### PR TITLE
Added support for Pro Controller Grip colors.

### DIFF
--- a/joycontrol/report.py
+++ b/joycontrol/report.py
@@ -149,7 +149,10 @@ class InputReport:
         self.data[offset + 3] = 0x02
         self.data[offset + 4: offset + 10] = mac
         self.data[offset + 10] = 0x01
-        self.data[offset + 11] = 0x01
+        if controller == Controller.PRO_CONTROLLER:
+            self.data[offset + 11] = 0x02
+        else:
+            self.data[offset + 11] = 0x01
 
     def sub_0x10_spi_flash_read(self, offset, size, data):
         if len(data) != size:


### PR DESCRIPTION
The color info field for the device info subcommand needs to be set to 2 instead of 1 for Pro Controllers so that the grip color customization they added in 5.0 works correctly.

Sorry for recreating this, forgot to do it to a branch so it added a bunch of unrelated commits to the old PR.