### PR TITLE
sharing paired session using unix socket

### DIFF
--- a/joycontrol/server.py
+++ b/joycontrol/server.py
@@ -95,6 +95,7 @@ async def create_hid_server(protocol_factory, ctl_psm=17, itr_psm=19, device_id=
     hid.discoverable(False)
 
     transport = L2CAP_Transport(asyncio.get_event_loop(), protocol, client_itr, 50, capture_file=capture_file)
+    transport.start_reading()
     protocol.connection_made(transport)
 
     # send some empty input reports until the Switch decides to reply

--- a/joycontrol/sharing.py
+++ b/joycontrol/sharing.py
@@ -1,0 +1,144 @@
+import asyncio
+import logging
+import pickle
+import os
+import array
+import struct
+import socket
+
+from joycontrol.protocol import controller_protocol_factory
+from joycontrol.transport import L2CAP_Transport
+
+
+logger = logging.getLogger(__name__)
+
+
+async def start_share_controller_server(protocol, server_address):
+    """Set up and start a sharing controller server.
+
+    Args:
+        - protocal: a running protocal instance. 
+        - server_address: a Unix socket path.
+    """
+    loop = asyncio.get_event_loop()
+
+    is_sharing_controller = False
+
+    async def handle_shared_controller_client_connected(conn):
+        logger.info("Handling incoming share request...")
+
+        nonlocal is_sharing_controller
+
+        async def return_error(error_msg):
+            logger.info("{}; cannot share controller".format(error_msg))
+            data = pickle.dumps({"status": "error", "msg": error_msg})
+            conn.sendall(array.pack('i', len(data)))
+            conn.sendall(data)
+            conn.close()
+
+        if is_sharing_controller:
+            return await return_error("Controller already shared to other process")
+
+        if not protocol.is_in_0x30_input_report_mode():
+            return await return_error("Protocol not in input report 0x30 mode")
+
+        try:
+            is_sharing_controller = True
+            protocol.pause_input_report_mode_0x30()
+
+            # Transfer the controller owner ship by sending over the bluetooth socket fd
+            transport = protocol.transport
+            client_itr_fd = transport.get_extra_info("socket").fileno()
+            data = pickle.dumps({
+                "status": "ok",
+                "controller": protocol.controller,
+                "spi_flash": protocol.spi_flash
+            })
+            conn.sendall(struct.pack('i', len(data)))
+            conn.sendmsg(
+                [b"fd"], 
+                [(socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", [client_itr_fd]))])
+            await loop.sock_sendall(conn, data)
+            await loop.sock_recv(conn, 1) # if we get back anything then we close the connection
+
+        except Exception as ex:
+            logger.debug(ex)
+
+        finally:
+            conn.close()
+            is_sharing_controller = False
+            protocol.start_input_report_mode_0x30()
+            logger.info("Re-gained Controller")
+            return True
+
+    logger.info(
+        "Starting unix server at {}; connect to this address to share the controller".format(server_address))
+    unix_server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    os.unlink(server_address)
+    unix_server_sock.bind(server_address)
+    unix_server_sock.setblocking(False)
+    unix_server_sock.listen()
+    while True:
+        conn, addr = await loop.sock_accept(unix_server_sock)
+        await handle_shared_controller_client_connected(conn)
+
+
+def recv_fds(sock, msglen, maxfds):
+    """Function from https://docs.python.org/3/library/socket.html#socket.socket.recvmsg"""
+    fds = array.array("i")   # Array of ints
+    msg, ancdata, flags, addr = sock.recvmsg(msglen, socket.CMSG_LEN(maxfds * fds.itemsize))
+    for cmsg_level, cmsg_type, cmsg_data in ancdata:
+        if (cmsg_level == socket.SOL_SOCKET and cmsg_type == socket.SCM_RIGHTS):
+            # Append data, ignoring any truncated integers at the end.
+            fds.fromstring(cmsg_data[:len(cmsg_data) - (len(cmsg_data) % fds.itemsize)])
+    return msg, list(fds)
+
+
+async def get_shared_controller(server_address, capture_file=None):
+    """Communicates with sharing server to setup a shared controller session.
+    
+    Given a sharing server address, returns a connected protocol object and a server socket.
+    The protocol object is a connected session that contains 
+    a ready-to-use controller state (running under 0x30 input mode).
+    The server_conn is a socket object, which if written or make closed, 
+    will close the connection to sharing server immediately. 
+    Note that this function do only minimal error handling. 
+    The caller is responsible for catching any exception and closing the server connection.
+
+    Args:
+        - server_address: a Unix socket path.
+        - capture_file: opened file for capturing transport output (for this shared session).
+
+    Returns:
+        A pair of (protocol, server_conn).
+    """
+
+    loop = asyncio.get_event_loop()
+
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    await loop.sock_connect(sock, server_address)
+
+    data_len, = struct.unpack('i', await loop.sock_recv(sock, 4))
+
+    msg, fds = recv_fds(sock, 2, 1)
+    assert msg == b"fd"
+
+    msg = b''
+    while len(msg) < data_len:
+        msg += await loop.sock_recv(sock, data_len - len(msg))
+
+    msg = pickle.loads(msg)
+    if msg.get("status") != "ok":
+        raise ValueError("Failed to connect to controller server: {}".format(msg.get("msg", "unknown error")))
+    
+    client_itr = socket.fromfd(fds[0], socket.AF_BLUETOOTH, socket.SOCK_SEQPACKET, socket.BTPROTO_L2CAP)
+    controller, spi_flash = msg['controller'], msg['spi_flash']
+    protocol = controller_protocol_factory(controller, spi_flash=spi_flash)()
+    transport = L2CAP_Transport(asyncio.get_event_loop(), protocol, client_itr, 50, capture_file=capture_file)
+    protocol.connection_made(transport)
+
+    # Start directly in input report 0x30 mode
+    asyncio.ensure_future(protocol.input_report_mode_0x30())
+
+    return protocol, sock
+

--- a/joycontrol/transport.py
+++ b/joycontrol/transport.py
@@ -36,7 +36,6 @@ class L2CAP_Transport(asyncio.Transport):
 
         self._is_closing = False
         self._is_reading = asyncio.Event()
-        self._is_reading.set()
 
         self._input_report_timer = 0x00
 
@@ -74,7 +73,7 @@ class L2CAP_Transport(asyncio.Transport):
         """
         self._is_reading.clear()
 
-    def resume_reading(self) -> None:
+    def start_reading(self) -> None:
         """
         Resumes the reader
         """

--- a/run_controller_cli.py
+++ b/run_controller_cli.py
@@ -10,15 +10,21 @@ from joycontrol.controller import Controller
 from joycontrol.memory import FlashMemory
 from joycontrol.protocol import controller_protocol_factory
 from joycontrol.server import create_hid_server
+from joycontrol.sharing import start_share_controller_server
+
 
 logger = logging.getLogger(__name__)
 
-
-async def _main(controller, capture_file=None, spi_flash=None, device_id=None):
+transport, protocol = None, None
+async def _main(controller, capture_file=None, spi_flash=None, device_id=None, share_controller_address=None):
     factory = controller_protocol_factory(controller, spi_flash=spi_flash)
+    global transport, protocol
     transport, protocol = await create_hid_server(factory, 17, 19, capture_file=capture_file, device_id=device_id)
 
     controller_state = protocol.get_controller_state()
+
+    if share_controller_address is not None:
+        asyncio.ensure_future(start_share_controller_server(protocol, share_controller_address))
 
     cli = ControllerCLI(controller_state)
     await cli.run()
@@ -34,13 +40,18 @@ if __name__ == '__main__':
 
     # setup logging
     #log.configure(console_level=logging.ERROR)
-    log.configure()
+    log.configure(console_level=logging.DEBUG)
 
     parser = argparse.ArgumentParser()
     parser.add_argument('controller', help='JOYCON_R, JOYCON_L or PRO_CONTROLLER')
     parser.add_argument('-l', '--log')
     parser.add_argument('-d', '--device_id')
     parser.add_argument('--spi_flash')
+    parser.add_argument('-s', '--share-controller', action="store_true",
+        help="Optional. Set to true to share this controller")
+    parser.add_argument('--share-controller-address', default=None, type=str,
+        help='A Unix socket address (i.e. path) to share the controller to other process; '
+             'defaults to /tmp/controller-<device_id>.sock')
     args = parser.parse_args()
 
     if args.controller == 'JOYCON_R':
@@ -70,8 +81,20 @@ if __name__ == '__main__':
         else:
             yield None
 
+    if args.share_controller:
+        if args.share_controller_address is None:
+            args.share_controller_address = "/tmp/controller-{}.sock".format(args.device_id)
+    else:
+        args.share_controller_address = None
+
     with get_output(args.log) as capture_file:
         loop = asyncio.get_event_loop()
         loop.run_until_complete(
-            _main(controller, capture_file=capture_file, spi_flash=spi_flash, device_id=args.device_id)
+            _main(
+                controller, 
+                capture_file=capture_file, 
+                spi_flash=spi_flash, 
+                device_id=args.device_id, 
+                share_controller_address=args.share_controller_address
+            )
         )

--- a/run_test_shared_controller_cli.py
+++ b/run_test_shared_controller_cli.py
@@ -1,0 +1,62 @@
+import argparse
+import asyncio
+import logging
+import os
+from contextlib import contextmanager
+
+from joycontrol import logging_default as log
+from joycontrol.command_line_interface import ControllerCLI
+from joycontrol.memory import FlashMemory
+from joycontrol.sharing import get_shared_controller
+
+async def _main(server_address, capture_file=None):
+    # We don't need to catch anything here
+    # just raise and exit the program if fails to connect
+    protocol, server_conn = await get_shared_controller(server_address, capture_file=capture_file)
+
+    print("You are using a shared controller. "
+      "You may exit the program at any time to yield the controller back to the sharing server.")
+
+    controller_state = protocol.get_controller_state()
+    cli = ControllerCLI(controller_state)
+    await cli.run()
+
+    logger.info('Yielding controller back to the sharing server...')
+    server_conn.close()
+
+if __name__ == '__main__':
+    # check if root
+    if not os.geteuid() == 0:
+        raise PermissionError('Script must be run as root!')
+
+    # setup logging
+    #log.configure(console_level=logging.ERROR)
+    log.configure()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-l', '--log')
+    parser.add_argument('--share-controller-address', default="/tmp/controller-None.sock", type=str,
+        help='A Unix socket address (i.e. path) to share the controller to other process')
+    args = parser.parse_args()
+
+    # creates file if arg is given
+    @contextmanager
+    def get_output(path=None):
+        """
+        Opens file if path is given
+        """
+        if path is not None:
+            file = open(path, 'wb')
+            yield file
+            file.close()
+        else:
+            yield None
+
+    with get_output(args.log) as capture_file:
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(
+            _main(
+                args.share_controller_address, 
+                capture_file=capture_file, 
+            )
+        )


### PR DESCRIPTION
This commit should give a relatively low-tech solution for persisting a paired session. 

The idea is that we have a server process that creates the initial controller and runs the protocol up until 0x30_input_mode; the server sets up a Unix socket server and listens for incoming request. 
Then a client connects to the unix socket. The server sends the bluetooth socket's fd to the client, and pauses its protocol loop. The client then starts the protocol loop immediately. 
The client yields back controller to server whenever the unix socket connection is closed.
