### PR TITLE
pause reading in transport now also affects input report modes

### DIFF
--- a/joycontrol/command_line_interface.py
+++ b/joycontrol/command_line_interface.py
@@ -4,6 +4,7 @@ import logging
 from aioconsole import ainput
 
 from joycontrol.controller_state import button_push, ControllerState
+from joycontrol.transport import NotConnectedError
 
 logger = logging.getLogger(__name__)
 
@@ -116,4 +117,8 @@ class ControllerCLI:
             if buttons_to_push:
                 await button_push(self.controller_state, *buttons_to_push)
             else:
-                await self.controller_state.send()
+                try:
+                    await self.controller_state.send()
+                except NotConnectedError:
+                    logger.info('Connection was lost.')
+                    return

--- a/joycontrol/controller_state.py
+++ b/joycontrol/controller_state.py
@@ -45,8 +45,11 @@ class ControllerState:
         return self._spi_flash
 
     async def send(self):
-        self.sig_is_send.clear()
-        await self.sig_is_send.wait()
+        """
+        Invokes protocol.send_controller_state(). Returns after the controller state was send.
+        Raises NotConnected exception if the connection was lost.
+        """
+        await self._protocol.send_controller_state()
 
     async def connect(self):
         """

--- a/joycontrol/server.py
+++ b/joycontrol/server.py
@@ -111,7 +111,7 @@ async def create_hid_server(protocol_factory, ctl_psm=17, itr_psm=19, device_id=
         client_itr.setblocking(False)
 
     # create transport for the established connection and activate the HID protocol
-    transport = L2CAP_Transport(asyncio.get_event_loop(), protocol, client_itr, 50, capture_file=capture_file)
+    transport = L2CAP_Transport(asyncio.get_event_loop(), protocol, client_itr, client_ctl, 50, capture_file=capture_file)
     protocol.connection_made(transport)
 
     # send some empty input reports until the Switch decides to reply

--- a/joycontrol/transport.py
+++ b/joycontrol/transport.py
@@ -4,8 +4,6 @@ import struct
 import time
 from typing import Any
 
-from joycontrol.report import InputReport
-
 logger = logging.getLogger(__name__)
 
 
@@ -23,35 +21,72 @@ class L2CAP_Transport(asyncio.Transport):
             'socket': self._sock
         }
 
+        self._is_closing = False
+        self._is_reading = asyncio.Event()
+
+        self._capture_file = capture_file
+
+        # start underlying reader
+        self._read_thread = None
+        self._is_reading.set()
+        self.start_reader()
+
+    async def _reader(self):
+        while True:
+            data = await self.read()
+
+            #logger.debug(f'received "{list(data)}"')
+            await self._protocol.report_received(data, self._sock.getpeername())
+
+    def start_reader(self):
+        """
+        Starts the transport reader which calls the protocols report_received function for every incoming message
+        """
+        if self._read_thread is not None:
+            raise ValueError('Reader is already running.')
+
         self._read_thread = asyncio.ensure_future(self._reader())
 
         # create callback to check for exceptions
         def callback(future):
             try:
                 future.result()
+            except asyncio.CancelledError:
+                # Future may be cancelled at anytime
+                pass
             except Exception as err:
                 logger.exception(err)
 
         self._read_thread.add_done_callback(callback)
 
-        self._is_closing = False
-        self._is_reading = asyncio.Event()
-        self._is_reading.set()
+    async def set_reader(self, reader: asyncio.Future):
+        """
+        Cancel the currently running reader and register the new one.
+        A reader is a coroutine that calls this transports 'read' function.
+        The 'read' function calls can be paused by calling pause_reading of this transport.
+        :param reader: future reader
+        """
+        if self._read_thread is not None:
+            # cancel currently running reader
+            self._read_thread.cancel()
+            try:
+                await self._read_thread
+            except asyncio.CancelledError:
+                pass
 
-        self._input_report_timer = 0x00
+        self._read_thread = reader
 
-        self._capture_file = capture_file
-
-    async def _reader(self):
-        while True:
-            await self._is_reading.wait()
-
-            data = await self.read()
-
-            #logger.debug(f'received "{list(data)}"')
-            await self._protocol.report_received(data, self._sock.getpeername())
+    def get_reader(self):
+        return self._read_thread
 
     async def read(self):
+        """
+        Read data from the unterlying socket. This function "blocks",
+        if reading is paused using the pause_reading function.
+
+        :returns bytes
+        """
+        await self._is_reading.wait()
         data = await self._loop.sock_recv(self._sock, self._read_buffer_size)
 
         if self._capture_file is not None:
@@ -66,7 +101,7 @@ class L2CAP_Transport(asyncio.Transport):
         """
         :returns True if the reader is running
         """
-        return self._is_reading.is_set()
+        return self._reader is not None and self._is_reading.is_set()
 
     def pause_reading(self) -> None:
         """
@@ -109,7 +144,7 @@ class L2CAP_Transport(asyncio.Transport):
 
     async def close(self):
         """
-        Stops socket reader and closes socket
+        Stops reader and closes underlying socket
         """
         self._is_closing = True
         self._read_thread.cancel()

--- a/joycontrol/utils.py
+++ b/joycontrol/utils.py
@@ -12,6 +12,25 @@ def flip_bit(value, n):
     return value ^ (1 << n)
 
 
+def create_error_check_callback(ignore=None):
+    """
+    Creates callback causing errors of a finished future to be raised.
+    Useful for debugging futures that are never awaited.
+    :param ignore: Any number of errors to ignore.
+    :returns callback which can be added to a future with future.add_done_callback(...)
+    """
+    def callback(future):
+        if ignore:
+            try:
+                future.result()
+            except ignore:
+                # ignore suppressed errors
+                pass
+        else:
+            future.result()
+    return callback
+
+
 async def run_system_command(cmd):
     proc = await asyncio.create_subprocess_shell(
         cmd,


### PR DESCRIPTION
Input report mode readers can be replaced with the transport reader, so that pause_reading and resume_reading functions in the transport affect all read calls.