### PR TITLE
Reconnect

### DIFF
--- a/joycontrol/server.py
+++ b/joycontrol/server.py
@@ -35,7 +35,8 @@ async def _run_protocol_on_connection(protocol, client_itr, capture_file=None):
         pass
 
 
-async def create_hid_server(protocol_factory, ctl_psm=17, itr_psm=19, device_id=None, capture_file=None):
+async def create_hid_server(protocol_factory, 
+    ctl_psm=17, itr_psm=19, device_id=None, reconnect_bt_addr=None, capture_file=None):
     """
     :param protocol_factory: Factory function returning a ControllerProtocol instance
     :param ctl_psm: hid control channel port
@@ -45,90 +46,84 @@ async def create_hid_server(protocol_factory, ctl_psm=17, itr_psm=19, device_id=
                       Bluetooth mac address in string notation of the adapter (e.g. "FF:FF:FF:FF:FF:FF").
                       If None, choose any device.
                       Note: Selection of adapters may currently not work if the bluez "input" plugin is enabled.
+    :param reconnect_bt_addr: the Bluetooth address of the console that was previously connected. Defaults to None.
+                      If None, a new hid server will be started for the initial paring.
+                      Otherwise, the function assumes an initial pairing with the console was already done and reconnects
+                      to the provided Bluetooth address.
     :param capture_file: opened file to log incoming and outgoing messages
     :returns transport for input reports and protocol which handles incoming output reports
     """
-    ctl_sock = socket.socket(socket.AF_BLUETOOTH, socket.SOCK_SEQPACKET, socket.BTPROTO_L2CAP)
-    itr_sock = socket.socket(socket.AF_BLUETOOTH, socket.SOCK_SEQPACKET, socket.BTPROTO_L2CAP)
-    ctl_sock.setblocking(False)
-    itr_sock.setblocking(False)
-    ctl_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    itr_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-    
-    try:
-        hid = HidDevice(device_id=device_id)
-
-        ctl_sock.bind((hid.address, ctl_psm))
-        itr_sock.bind((hid.address, itr_psm))
-    except OSError as err:
-        logger.warning(err)
-        # If the ports are already taken, this probably means that the bluez "input" plugin is enabled.
-        logger.warning('Fallback: Restarting bluetooth due to incompatibilities with the bluez "input" plugin. '
-                       'Disable the plugin to avoid issues. See https://github.com/mart1nro/joycontrol/issues/8.')
-        # HACK: To circumvent incompatibilities with the bluetooth "input" plugin, we need to restart Bluetooth here.
-        # The Switch does not connect to the sockets if we don't.
-        # For more info see: https://github.com/mart1nro/joycontrol/issues/8
-        logger.info('Restarting bluetooth service...')
-        await utils.run_system_command('systemctl restart bluetooth.service')
-        await asyncio.sleep(1)
-
-        hid = HidDevice(device_id=device_id)
-
-        ctl_sock.bind((socket.BDADDR_ANY, ctl_psm))
-        itr_sock.bind((socket.BDADDR_ANY, itr_psm))
-
-    ctl_sock.listen(1)
-    itr_sock.listen(1)
-
     protocol = protocol_factory()
 
-    hid.powered(True)
-    # setting bluetooth adapter name and class to the device we wish to emulate
-    await hid.set_name(protocol.controller.device_name())
-    await hid.set_class()
+    if reconnect_bt_addr is None:
+        ctl_sock = socket.socket(socket.AF_BLUETOOTH, socket.SOCK_SEQPACKET, socket.BTPROTO_L2CAP)
+        itr_sock = socket.socket(socket.AF_BLUETOOTH, socket.SOCK_SEQPACKET, socket.BTPROTO_L2CAP)
+        ctl_sock.setblocking(False)
+        itr_sock.setblocking(False)
+        ctl_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        itr_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        
+        try:
+            hid = HidDevice(device_id=device_id)
 
-    logger.info('Advertising the Bluetooth SDP record...')
-    try:
-        HidDevice.register_sdp_record(PROFILE_PATH)
-    except dbus.exceptions.DBusException as dbus_err:
-        # Already registered (If multiple controllers are being emulated and this method is called consecutive times)
-        logger.debug(dbus_err)
+            ctl_sock.bind((hid.address, ctl_psm))
+            itr_sock.bind((hid.address, itr_psm))
+        except OSError as err:
+            logger.warning(err)
+            # If the ports are already taken, this probably means that the bluez "input" plugin is enabled.
+            logger.warning('Fallback: Restarting bluetooth due to incompatibilities with the bluez "input" plugin. '
+                           'Disable the plugin to avoid issues. See https://github.com/mart1nro/joycontrol/issues/8.')
+            # HACK: To circumvent incompatibilities with the bluetooth "input" plugin, we need to restart Bluetooth here.
+            # The Switch does not connect to the sockets if we don't.
+            # For more info see: https://github.com/mart1nro/joycontrol/issues/8
+            logger.info('Restarting bluetooth service...')
+            await utils.run_system_command('systemctl restart bluetooth.service')
+            await asyncio.sleep(1)
 
-    # start advertising
-    hid.discoverable()
+            hid = HidDevice(device_id=device_id)
 
-    logger.info('Waiting for Switch to connect... Please open the "Change Grip/Order" menu.')
+            ctl_sock.bind((socket.BDADDR_ANY, ctl_psm))
+            itr_sock.bind((socket.BDADDR_ANY, itr_psm))
 
-    loop = asyncio.get_event_loop()
-    client_ctl, ctl_address = await loop.sock_accept(ctl_sock)
-    logger.info(f'Accepted connection at psm {ctl_psm} from {ctl_address}')
-    client_itr, itr_address = await loop.sock_accept(itr_sock)
-    logger.info(f'Accepted connection at psm {itr_psm} from {itr_address}')
-    assert ctl_address[0] == itr_address[0]
+        ctl_sock.listen(1)
+        itr_sock.listen(1)
 
-    # stop advertising
-    hid.discoverable(False)
+        hid.powered(True)
+        # setting bluetooth adapter name and class to the device we wish to emulate
+        await hid.set_name(protocol.controller.device_name())
+        await hid.set_class()
+
+        logger.info('Advertising the Bluetooth SDP record...')
+        try:
+            HidDevice.register_sdp_record(PROFILE_PATH)
+        except dbus.exceptions.DBusException as dbus_err:
+            # Already registered (If multiple controllers are being emulated and this method is called consecutive times)
+            logger.debug(dbus_err)
+
+        # start advertising
+        hid.discoverable()
+
+        logger.info('Waiting for Switch to connect... Please open the "Change Grip/Order" menu.')
+
+        loop = asyncio.get_event_loop()
+        client_ctl, ctl_address = await loop.sock_accept(ctl_sock)
+        logger.info(f'Accepted connection at psm {ctl_psm} from {ctl_address}')
+        client_itr, itr_address = await loop.sock_accept(itr_sock)
+        logger.info(f'Accepted connection at psm {itr_psm} from {itr_address}')
+        assert ctl_address[0] == itr_address[0]
+
+        # stop advertising
+        hid.discoverable(False)
+
+    else:
+        # Reconnection to reconnect_bt_addr
+        client_ctl = socket.socket(socket.AF_BLUETOOTH, socket.SOCK_SEQPACKET, socket.BTPROTO_L2CAP)
+        client_itr = socket.socket(socket.AF_BLUETOOTH, socket.SOCK_SEQPACKET, socket.BTPROTO_L2CAP)
+        client_ctl.connect((reconnect_bt_addr, ctl_psm))
+        client_itr.connect((reconnect_bt_addr, itr_psm))
+        client_ctl.setblocking(False)
+        client_itr.setblocking(False)
 
     await _run_protocol_on_connection(protocol, client_itr, capture_file=capture_file)
 
     return protocol.transport, protocol
-
-
-async def create_reconnection(protocol_factory, console_bt_addr, ctl_psm=17, itr_psm=19, capture_file=None):
-    """Setup a running protocal by reconnecting to a pairsed console.
-    
-    :param console_bt_addr: a bluetooth address for the Switch console.
-    :param *args, **kwargs: see `create_hid_server`, except that `create_reconnection` does not require device_id.
-    :returns: see `create_hid_server`
-    """
-    protocol = protocol_factory()
-    client_ctl = socket.socket(socket.AF_BLUETOOTH, socket.SOCK_SEQPACKET, socket.BTPROTO_L2CAP)
-    client_itr = socket.socket(socket.AF_BLUETOOTH, socket.SOCK_SEQPACKET, socket.BTPROTO_L2CAP)
-    client_ctl.connect((console_bt_addr, ctl_psm))
-    client_itr.connect((console_bt_addr, itr_psm))
-    client_ctl.setblocking(False)
-    client_itr.setblocking(False)
-
-    await _run_protocol_on_connection(protocol, client_itr)
-    transport = protocol.transport
-    return transport, protocol

--- a/run_controller_cli.py
+++ b/run_controller_cli.py
@@ -10,22 +10,18 @@ from joycontrol.command_line_interface import ControllerCLI
 from joycontrol.controller import Controller
 from joycontrol.memory import FlashMemory
 from joycontrol.protocol import controller_protocol_factory
-from joycontrol.server import create_hid_server, create_reconnection
+from joycontrol.server import create_hid_server
 from joycontrol.report import InputReport
 
 logger = logging.getLogger(__name__)
 
 
-async def _main(controller, console_bt_addr=None, capture_file=None, spi_flash=None, device_id=None):
+async def _main(controller, reconnect_bt_addr=None, capture_file=None, spi_flash=None, device_id=None):
     factory = controller_protocol_factory(controller, spi_flash=spi_flash)
     ctl_psm, itr_psm = 17, 19
-    if console_bt_addr is None:
-        transport, protocol = await create_hid_server(factory, 
-            ctl_psm=ctl_psm, itr_psm=itr_psm, capture_file=capture_file, device_id=device_id)
-    else:
-        transport, protocol = await create_reconnection(factory, 
-            console_bt_addr,
-            ctl_psm=ctl_psm, itr_psm=itr_psm, capture_file=capture_file)
+    transport, protocol = await create_hid_server(factory, 
+        reconnect_bt_addr=reconnect_bt_addr,
+        ctl_psm=ctl_psm, itr_psm=itr_psm, capture_file=capture_file, device_id=device_id)
 
     controller_state = protocol.get_controller_state()
 
@@ -50,7 +46,8 @@ if __name__ == '__main__':
     parser.add_argument('-l', '--log')
     parser.add_argument('-d', '--device_id')
     parser.add_argument('--spi_flash')
-    parser.add_argument('--console-bt-addr', type=str, default=None)
+    parser.add_argument('-r', '--reconnect_bt_addr', type=str, default=None, 
+        help='The Switch console bluetooth address, for reconnecting as an already paired controller')
     args = parser.parse_args()
 
     if args.controller == 'JOYCON_R':
@@ -84,7 +81,7 @@ if __name__ == '__main__':
         loop = asyncio.get_event_loop()
         loop.run_until_complete(
             _main(controller, 
-                console_bt_addr=args.console_bt_addr, 
+                reconnect_bt_addr=args.reconnect_bt_addr, 
                 capture_file=capture_file, 
                 spi_flash=spi_flash, 
                 device_id=args.device_id

--- a/run_controller_cli.py
+++ b/run_controller_cli.py
@@ -2,7 +2,6 @@ import argparse
 import asyncio
 import logging
 import os
-import socket
 from contextlib import contextmanager
 
 from joycontrol import logging_default as log
@@ -11,7 +10,6 @@ from joycontrol.controller import Controller
 from joycontrol.memory import FlashMemory
 from joycontrol.protocol import controller_protocol_factory
 from joycontrol.server import create_hid_server
-from joycontrol.report import InputReport
 
 logger = logging.getLogger(__name__)
 
@@ -19,9 +17,8 @@ logger = logging.getLogger(__name__)
 async def _main(controller, reconnect_bt_addr=None, capture_file=None, spi_flash=None, device_id=None):
     factory = controller_protocol_factory(controller, spi_flash=spi_flash)
     ctl_psm, itr_psm = 17, 19
-    transport, protocol = await create_hid_server(factory, 
-        reconnect_bt_addr=reconnect_bt_addr,
-        ctl_psm=ctl_psm, itr_psm=itr_psm, capture_file=capture_file, device_id=device_id)
+    transport, protocol = await create_hid_server(factory, reconnect_bt_addr=reconnect_bt_addr, ctl_psm=ctl_psm,
+                                                  itr_psm=itr_psm, capture_file=capture_file, device_id=device_id)
 
     controller_state = protocol.get_controller_state()
 
@@ -46,8 +43,8 @@ if __name__ == '__main__':
     parser.add_argument('-l', '--log')
     parser.add_argument('-d', '--device_id')
     parser.add_argument('--spi_flash')
-    parser.add_argument('-r', '--reconnect_bt_addr', type=str, default=None, 
-        help='The Switch console bluetooth address, for reconnecting as an already paired controller')
+    parser.add_argument('-r', '--reconnect_bt_addr', type=str, default=None,
+                        help='The Switch console Bluetooth address, for reconnecting as an already paired controller')
     args = parser.parse_args()
 
     if args.controller == 'JOYCON_R':
@@ -80,10 +77,10 @@ if __name__ == '__main__':
     with get_output(args.log) as capture_file:
         loop = asyncio.get_event_loop()
         loop.run_until_complete(
-            _main(controller, 
-                reconnect_bt_addr=args.reconnect_bt_addr, 
-                capture_file=capture_file, 
-                spi_flash=spi_flash, 
-                device_id=args.device_id
-            )
+            _main(controller,
+                  reconnect_bt_addr=args.reconnect_bt_addr,
+                  capture_file=capture_file,
+                  spi_flash=spi_flash,
+                  device_id=args.device_id
+                  )
         )


### PR DESCRIPTION
This again attempts to solve #14, and overrides PR #15, which I will close now.

After playing around and debugging, I realized that the only thing that was needed for a reconnection, is to connect to both the client_ctl and client_itr sockets. That's it! 

You can test the implementation with for example:
```
$ python run_controller_cli.py JOYCON_L # sets up initial paring as before
$ ^Ctrl-C
$ python run_controller_cli.py --console-bt-addr 'xx:xx:xx:xx"  JOYCON_L # put your Switch BT address
```  