### PR TITLE
changed order of device class setting

### DIFF
--- a/joycontrol/server.py
+++ b/joycontrol/server.py
@@ -75,9 +75,8 @@ async def create_hid_server(protocol_factory, ctl_psm=17, itr_psm=19, device_id=
         itr_sock.listen(1)
 
         hid.powered(True)
-        # setting bluetooth adapter name and class to the device we wish to emulate
+        # setting bluetooth adapter name to the device we wish to emulate
         await hid.set_name(protocol.controller.device_name())
-        await hid.set_class()
 
         logger.info('Advertising the Bluetooth SDP record...')
         try:
@@ -85,6 +84,8 @@ async def create_hid_server(protocol_factory, ctl_psm=17, itr_psm=19, device_id=
         except dbus.exceptions.DBusException as dbus_err:
             # Already registered (If multiple controllers are being emulated and this method is called consecutive times)
             logger.debug(dbus_err)
+
+        await hid.set_class()
 
         # start advertising
         hid.discoverable()


### PR DESCRIPTION
Pull request to fix #20 

Registering the Bluetooth SDP record seems to cause the device class to be reset to 0x000c010c.
Should further investigate why that happens...

Hotfix: Changed the order of setting the device class to after registering the SDP record.