### PR TITLE
Include the libhidapi-hidraw0 library in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ Emulate Nintendo Switch Controllers over Bluetooth.
 Tested on Ubuntu 19.10 and with Raspberry Pi 4B Raspbian GNU/Linux 10 (buster)
 
 ## Installation
-- Install dbus-python package
+- Install the dbus-python and libhidapi-hidraw0 packages
 ```bash
-sudo apt install python3-dbus
+sudo apt install python3-dbus libhidapi-hidraw0
 ```
 - Clone the repository and install the joycontrol package to get missing dependencies (Note: Controller script needs super user rights, so python packages must be installed as root). In the joycontrol folder run:
 ```bash


### PR DESCRIPTION
I needed to install `libhidapi-hidraw0` to get the program to run. Using a raspberry pi

```
pi@raspberrypi:~/joycontrol $ sudo python3 run_controller_cli.py PRO_CONTROLLER
Traceback (most recent call last):
  File "run_controller_cli.py", line 11, in <module>
    from joycontrol import logging_default as log, utils
  File "/home/pi/joycontrol/joycontrol/utils.py", line 5, in <module>
    import hid
  File "/usr/local/lib/python3.7/dist-packages/hid/__init__.py", line 30, in <module>
    raise ImportError(error)
ImportError: Unable to load any of the following libraries:libhidapi-hidraw.so libhidapi-hidraw.so.0 libhidapi-libusb.so libhidapi-libusb.so.0 libhidapi-iohidmanager.so libhidapi-iohidmanager.so.0 libhidapi.dylib hidapi.dll libhidapi-0.dll
pi@raspberrypi:~/joycontrol $ sudo apt-get install -y libhidapi-hidraw0
```