### PR TITLE
Adjusting size of source amiibo file

### DIFF
--- a/joycontrol/ir_nfc_mcu.py
+++ b/joycontrol/ir_nfc_mcu.py
@@ -131,7 +131,7 @@ class IrNfcMcu:
             else:
                 data = bytes.fromhex('02000927')
                 copyarray(self._bytes, 3, data)
-                copyarray(self._bytes, 3 + len(data), self._nfc_content[245:])
+                copyarray(self._bytes, 3 + len(data), self._nfc_content[245:540])
                 self.set_action(Action.READ_FINISHED)
         elif self.get_action() == Action.READ_FINISHED:
             self._bytes[0] = 0x2a


### PR DESCRIPTION
When scanning amiibo binaries over 540 bytes like Twilight Princess Link, Rider Link and other new ones an out of range error is thrown. Just writing up to the byte 540 of the source file solves this error. This is similar to TagMo implementation for bigger amiibos.