### PR TITLE
Adding a mash_button function

### DIFF
--- a/run_controller_cli.py
+++ b/run_controller_cli.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 While running the cli, call "help" for an explanation of available commands.
 
 Usage:
-    run_controller_cli.py <controller> [--device_id | -d  <bluetooth_adapter_id>] 
+    run_controller_cli.py <controller> [--device_id | -d  <bluetooth_adapter_id>]
                                        [--spi_flash <spi_flash_memory_file>]
                                        [--reconnect_bt_addr | -r <console_bluetooth_address>]
                                        [--log | -l <communication_log_file>]
@@ -33,7 +33,7 @@ Arguments:
 
 Options:
     -d --device_id <bluetooth_adapter_id>   ID of the bluetooth adapter. Integer matching the digit in the hci* notation
-                                            (e.g. hci0, hci1, ...) or Bluetooth mac address of the adapter in string 
+                                            (e.g. hci0, hci1, ...) or Bluetooth mac address of the adapter in string
                                             notation (e.g. "FF:FF:FF:FF:FF:FF").
                                             Note: Selection of adapters may not work if the bluez "input" plugin is
                                             enabled.
@@ -41,11 +41,11 @@ Options:
     --spi_flash <spi_flash_memory_file>     Memory dump of a real Switch controller. Required for joystick emulation.
                                             Allows displaying of JoyCon colors.
                                             Memory dumps can be created using the dump_spi_flash.py script.
-                                            
-    -r --reconnect_bt_addr <console_bluetooth_address>  Previously connected Switch console Bluetooth address in string 
+
+    -r --reconnect_bt_addr <console_bluetooth_address>  Previously connected Switch console Bluetooth address in string
                                                         notation (e.g. "FF:FF:FF:FF:FF:FF") for reconnection.
                                                         Does not require the "Change Grip/Order" menu to be opened,
-    
+
     -l --log <communication_log_file>       Write hid communication (input reports and output reports) to a file.
 """
 
@@ -179,6 +179,39 @@ async def _main(args):
 
         # add the script from above
         cli.add_command('test_buttons', _run_test_controller_buttons)
+
+        # Mash a button command
+        async def mash_button(*args):
+            """
+            mash_button - Mash a specified button at a set interval
+
+            Usage:
+                mash_button <button> <interval>
+            """
+
+            if not len(args) == 2:
+                raise ValueError('"mash_button" command requires a button and interval as arguments!')
+
+            # waits until controller is fully connected
+            await controller_state.connect()
+
+            user_input = asyncio.ensure_future(
+                ainput(prompt='Pressing the '+args[0]+' button every '+args[1]+' seconds forever... Press <enter> to stop.')
+            )
+
+            # push a button repeatedly until user input
+            while not user_input.done():
+                await button_push(controller_state, args[0])
+                await asyncio.sleep(float(args[1]))
+
+                if user_input.done():
+                    break
+
+            # await future to trigger exceptions in case something went wrong
+            await user_input
+
+        # add the script from above
+        cli.add_command('mash_button', mash_button)
 
         # Create amiibo command
         async def amiibo(*args):


### PR DESCRIPTION
Certain games mandate pressing a single button over and over (e.g. Animal Crossing: New Horizon’s crafting system). This PR adds a `mash_button` command that accepts a button and interval as arguments and then presses the button until it receives user input.