### PR TITLE
Fix NFC (Fixes Breath of the Wild comms error)

### DIFF
--- a/joycontrol/ir_nfc_mcu.py
+++ b/joycontrol/ir_nfc_mcu.py
@@ -143,6 +143,7 @@ class IrNfcMcu:
             copyarray(self._bytes, 5, data)
             copyarray(self._bytes, 5 + len(data), self._nfc_content[0:3])
             copyarray(self._bytes, 5 + len(data) + 3, self._nfc_content[4:8])
+            self.set_action(Action.NON)
 
         crc = crc8()
         crc.update(bytes(self._bytes[:-1]))


### PR DESCRIPTION
This specifically is targeted at Breath of the Wild. The reason that the NFC is listed as broken by the switch is that the application is spamming it with finished reading tags which because of a delay in response or code not able to take the extra responses from the game is causing an error.

Ideally, it would stop looking at this data altogether after this though this is a quick simple fix tested on the latest breath of the wild and firmware.