### PR TITLE
Convert run_system_command to use _exec instead of _shell

### DIFF
--- a/joycontrol/device.py
+++ b/joycontrol/device.py
@@ -59,7 +59,7 @@ class HidDevice:
         :param cls: default 0x002508 (Gamepad/joystick device class)
         """
         logger.info(f'setting device class to {cls}...')
-        await utils.run_system_command(f'hciconfig {self._adapter_name} class {cls}')
+        await utils.run_system_command(['hciconfig', self._adapter_name, 'class', cls])
 
     async def set_name(self, name: str):
         """

--- a/joycontrol/server.py
+++ b/joycontrol/server.py
@@ -63,7 +63,7 @@ async def create_hid_server(protocol_factory, ctl_psm=17, itr_psm=19, device_id=
             # The Switch does not connect to the sockets if we don't.
             # For more info see: https://github.com/mart1nro/joycontrol/issues/8
             logger.info('Restarting bluetooth service...')
-            await utils.run_system_command('systemctl restart bluetooth.service')
+            await utils.run_system_command(['systemctl', 'restart', 'bluetooth.service'])
             await asyncio.sleep(1)
 
             hid = HidDevice(device_id=device_id)

--- a/joycontrol/utils.py
+++ b/joycontrol/utils.py
@@ -65,8 +65,8 @@ def create_error_check_callback(ignore=None):
 
 
 async def run_system_command(cmd):
-    proc = await asyncio.create_subprocess_shell(
-        cmd,
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE)
 


### PR DESCRIPTION
While probably harmless, use of _shell opens us up to argument injection
via e.g. malformed device names.