### PR TITLE
Feature: Amiibo NFC reading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Tested on Ubuntu 19.10, and with Raspberry Pi 3B+ and 4B Raspbian GNU/Linux 10 (
 Emulation of JOYCON_R, JOYCON_L and PRO_CONTROLLER. Able to send:
 - button commands
 - stick state
-- ~~nfc data~~ (removed, see [#80](https://github.com/mart1nro/joycontrol/issues/80))
+- nfc data read
 
 ## Installation
 - Install dependencies
@@ -51,7 +51,7 @@ Call "help" to see a list of available commands.
 - Some bluetooth adapters seem to cause disconnects for reasons unknown, try to use an usb adapter instead 
 - Incompatibility with Bluetooth "input" plugin requires a bluetooth restart, see [#8](https://github.com/mart1nro/joycontrol/issues/8)
 - It seems like the Switch is slower processing incoming messages while in the "Change Grip/Order" menu.
-  This causes flooding of packets and makes pairing somewhat inconsistent.
+  This causes flooding of packets and makes input after initial pairing somewhat inconsistent.
   Not sure yet what exactly a real controller does to prevent that.
   A workaround is to use the reconnect option after a controller was paired once, so that
   opening of the "Change Grip/Order" menu is not required.

--- a/joycontrol/mcu.py
+++ b/joycontrol/mcu.py
@@ -14,7 +14,7 @@ def debug(args):
 ###############################################################
 ## This simulates the MCU in the right joycon/Pro-Controller ##
 ###############################################################
-# This is sufficient to read one amiibo
+# This is sufficient to read one amiibo when simulation Pro-Controller
 # multiple can mess up the internal state
 # anything but amiboo is not supported
 # TODO:
@@ -22,6 +22,7 @@ def debug(args):
 #       see https://github.com/CTCaer/jc_toolkit/blob/5.2.0/jctool/jctool.cpp l2456ff for sugesstions
 #     - IR-camera
 #     - writing to Amiibo
+#     - verify right joycon
 
 # These Values are used in set_power, set_config and get_status packets
 # But not all of them can appear in every one
@@ -70,21 +71,36 @@ class NFC_state(enum.Enum):
     POLL_AGAIN = 0x09
 
 
-class MCU_Message:
-    def __init__(self, *args, background=0, checksum=MCU_crc):
-        self.data = bytearray([background] * 313)
-        c = 0
-        for i in args:
-            if isinstance(i, str):
-                b = bytes.fromhex(i)
-            else:
-                b = bytes(i)
-            self.data[c:c+len(b)] = b
-        if checksum:
-            self.data[-1] = checksum(self.data[0:-1])
+def pack_message(*args, background=0, checksum=MCU_crc):
+    """
+    convinience function that packes
+    * hex strings
+    * byte lists
+    * integer lists
+    * Enums
+    * integers
+    into a 313 bytes long MCU response
+    """
+    data = bytearray([background] * 313)
+    cur = 0
+    for arg in args:
+        if isinstance(arg, str):
+            arg = bytes.fromhex(arg)
+        elif isinstance(arg, int):
+            arg = bytes([arg])
+        elif isinstance(arg, enum.Enum):
+            arg = bytes([arg.value])
+        else:
+            arg = bytes(arg)
+        arg_len = len(arg)
+        if arg_len + cur > 313:
+            logger.warn("MCU: too long message packed")
+        data[cur:cur+arg_len] = arg
+        cur += arg_len
+    if checksum:
+        data[-1] = checksum(data[0:-1])
+    return data
 
-    def __bytes__(self):
-        return self.data
 
 class MarvelCinematicUniverse:
     def __init__(self, controller: ControllerState):
@@ -108,15 +124,10 @@ class MarvelCinematicUniverse:
 
         # We are getting 0x11 commands to do something, but cannot answer directly
         # responses have to be passed in regular input reports
-        # If there was no Command, this is the default report
-        self.no_response = [0] * 313
-        self.no_response[0] = 0xff
-        self.no_response[-1] = MCU_crc(self.no_response[:-1])
+        # If there was no command, this is the default report
+        self.no_response = pack_message(0xff)
         self.response_queue = []
         self.max_response_queue_len = 3
-
-        #debug
-        self.reading = 0
 
     def _flush_response_queue(self):
         self.response_queue = []
@@ -134,6 +145,7 @@ class MarvelCinematicUniverse:
     def set_remove_nfc_after_read(self, value):
         self.remove_nfc_after_read = value
 
+    # called somwhere in get_nfc_status with _controller.get_nfc()
     def set_nfc_tag_data(self, data):
         logger.info("MCU-NFC: set NFC tag data")
         if not data:
@@ -145,12 +157,6 @@ class MarvelCinematicUniverse:
             return
         self.nfc_tag_data = data
 
-    def entered_31_input_mode(self):
-        resp = [0] * 313
-        resp[0:8] = bytes.fromhex("0100000008001b01")
-        resp[-1] = MCU_crc(resp[:-1])
-        self._queue_response(resp)
-
     def _get_status_data(self, args=None):
         """
         create a status packet to be used when responding to 1101 commands
@@ -159,40 +165,79 @@ class MarvelCinematicUniverse:
             logger.warning("MCU: status request when disabled")
             return self.no_response
         elif self.power_state.value in GET_STATUS_VALUES:
-            resp = [0] * 313
-            resp[0:7] = bytes.fromhex("0100000008001b")
-            resp[7] = self.power_state.value
-            resp[-1] = MCU_crc(resp[:-1])
-            return resp
-            #self._queue_response(resp)
-            #return self._get_status_data()
-        #else:
-            #out = [0] * 313
-            #out[0:7] = bytes.fromhex("01000000030005")
-            #out[7] = MCUPowerState.READY.value
-            #out[-1] = MCU_crc(out[0:-1])
-            #return out
+            return pack_message("0100000008001b", self.power_state)
 
     def _get_nfc_status_data(self, args):
-        out = [0] * 313
-        out[0:7] = bytes.fromhex("2a000500000931")
-        out[7] = self.nfc_state.value
         if self.nfc_state == NFC_state.POLL and self._controller.get_nfc():
             self.set_nfc_tag_data(self._controller.get_nfc())
         if self.nfc_tag_data and self.nfc_state in (NFC_state.POLL, NFC_state.POLL_AGAIN):
-            out[8:16] = bytes.fromhex("0000000101020007")
-            out[16:19] = self.nfc_tag_data[0:3]
-            out[19:23] = self.nfc_tag_data[4:8]
+            out = pack_message("2a000500000931", self.nfc_state, "0000000101020007", self.nfc_tag_data[0:3], self.nfc_tag_data[4:8])
             self.nfc_state = NFC_state.POLL_AGAIN
-        out[-1] = MCU_crc(out[0:-1])
+        else:
+            out = pack_message("2a000500000931", self.nfc_state)
         self._queue_response(out)
         self._queue_response(out)
         return out
+
+    def handle_nfc_subcommand(self, com, data):
+        """
+        This generates responses for NFC commands and thus implements the entire
+        NFC-behaviour
+        @param com: the NFC-command (not the 0x02, the byte after that)
+        @param data: the remaining data
+        """
+        if com == 0x04:  # status / response request
+            self._queue_response(self._get_nfc_status_data(data))
+        elif com == 0x01:  # start polling, should we queue a nfc_status?
+            logger.info("MCU-NFC: start polling")
+            self.nfc_state = NFC_state.POLL
+        elif com == 0x06:  # read, we probably should not respond to this at all,
+            # since each packet is queried individually by the switch, but parsing these
+            # 04 packets is just annoying
+            logger.info("MCU-NFC: reading Tag...")
+            if self.nfc_tag_data:
+                self._flush_response_queue()
+                # Data is sent in 2 packages plus a trailer
+                # the first one contains a lot of fixed header and the UUID
+                # the length and packetnumber is in there somewhere, see
+                # https://github.com/CTCaer/jc_toolkit/blob/5.2.0/jctool/jctool.cpp line 2523ff
+                self._force_queue_response(pack_message(
+                        "3a0007010001310200000001020007",
+                        self.nfc_tag_data[0:3],
+                        self.nfc_tag_data[4:8],
+                        "000000007DFDF0793651ABD7466E39C191BABEB856CEEDF1CE44CC75EAFB27094D087AE803003B3C7778860000",
+                        self.nfc_tag_data[0:245]
+                ))
+                # the second one is mostely data, followed by presumably anything (zeroes work)
+                self._force_queue_response(pack_message(
+                        "3a000702000927",
+                        self.nfc_tag_data[245:540]
+                ))
+                # the trailer includes the UUID again
+                self._force_queue_response(pack_message(
+                        "2a000500000931040000000101020007",
+                        self.nfc_tag_data[0:3],
+                        self.nfc_tag_data[4:8]
+                ))
+                #self.nfc_tag_data = None
+                #if self.remove_nfc_after_read:
+                #    self._controller.set_nfc(None)
+        # elif com == 0x00: # cancel eveyhting -> exit mode?
+        elif com == 0x02:  # stop polling, respond?
+            logger.info("MCU-NFC: stop polling...")
+            self.nfc_state = NFC_state.NONE
+        else:
+            logger.error("unhandled NFC subcommand", com, data)
 
     # I don't actually know if we are supposed to change the MCU-data based on
     # regular subcommands, but the switch is spamming the status-requests anyway,
     # so sending responses seems to not hurt
 
+    # protocoll-callback
+    def entered_31_input_mode(self):
+        self._queue_response(pack_message("0100000008001b01"))
+
+    # protocoll-callback
     def set_power_state_cmd(self, power_state):
         logger.info(f"MCU: Set power state cmd {power_state}")
         if power_state in SET_POWER_VALUES:
@@ -202,6 +247,7 @@ class MarvelCinematicUniverse:
             self.power_state = MCUPowerState.READY
         self._queue_response(self._get_status_data())
 
+    # protocoll-callback
     def set_config_cmd(self, config):
         if self.power_state == MCUPowerState.SUSPENDED:
             if config[2] == 0:
@@ -222,63 +268,7 @@ class MarvelCinematicUniverse:
                 self.nfc_state = NFC_state.NONE
             self._queue_response(self._get_status_data())
 
-    def handle_nfc_subcommand(self, com, data):
-        """
-        This generates responses for NFC commands and thus implements the entire
-        NFC-behaviour
-        @param com: the NFC-command (not the 0x02, the byte after that)
-        @param data: the remaining data
-        """
-        if com == 0x04:  # status / response request
-            self._queue_response(self._get_nfc_status_data(data))
-        elif com == 0x01:  # start polling, should we queue a nfc_status?
-            logger.info("MCU-NFC: start polling")
-            self.nfc_state = NFC_state.POLL
-        elif com == 0x06:  # read, we probably should not respond to this at all,
-            # since each packet is queried individually by the switch, but parsing these
-            # 04 packets is just annoying
-            logger.info("MCU-NFC: reading...")
-            if self.nfc_tag_data:
-                self._flush_response_queue()
-                # Data is sent in 2 packages plus a trailer
-                # the first one contains a lot of fixed header and the UUID
-                # the length and packetnumber is in there somewhere, see
-                # https://github.com/CTCaer/jc_toolkit/blob/5.2.0/jctool/jctool.cpp line 2523ff
-                out = [0] * 313
-                out[0:15] = bytes.fromhex("3a0007010001310200000001020007")
-                out[15:18] = self.nfc_tag_data[0:3]
-                out[18:22] = self.nfc_tag_data[4:8]
-                out[22:67] = bytes.fromhex(
-                    "000000007DFDF0793651ABD7466E39C191BABEB856CEEDF1CE44CC75EAFB27094D087AE803003B3C7778860000")
-                out[67:-1] = self.nfc_tag_data[0:245]
-                out[-1] = MCU_crc(out[0:-1])
-                self._force_queue_response(out)
-                # the second one is mostely data, followed by presumably anything (zeroes work)
-                out = [0] * 313
-                out[0:7] = bytes.fromhex("3a000702000927")
-                out[7:302] = self.nfc_tag_data[245:540]
-                out[-1] = MCU_crc(out[0:-1])
-                self._force_queue_response(out)
-                # the trailer includes the UUID again
-                out = [0] * 313
-                out[0:16] = bytes.fromhex("2a000500000931040000000101020007")
-                out[16:19] = self.nfc_tag_data[0:3]
-                out[19:23] = self.nfc_tag_data[4:8]
-                out[-1] = MCU_crc(out[0:-1])
-                self._force_queue_response(out)
-                self.reading = 3
-                for msg in self.response_queue:
-                    print("MCU-NFC: reading, queued", msg)
-                #self.nfc_tag_data = None
-                #if self.remove_nfc_after_read:
-                #    self._controller.set_nfc(None)
-        # elif com == 0x00: # cancel eveyhting -> exit mode?
-        elif com == 0x02:  # stop polling, respond?
-            logger.info("MCU-NFC: stop polling...")
-            self.nfc_state = NFC_state.NONE
-        else:
-            logger.error("unhandled NFC subcommand", com, data)
-
+    # protocoll-callback
     def received_11(self, subcommand, subcommanddata):
         """
         This function handles all 0x11 output-reports.
@@ -298,6 +288,7 @@ class MarvelCinematicUniverse:
         else:
             logger.error("unknown 11 subcommand", subcommand, subcommanddata)
 
+    # protocoll hook
     def get_data(self):
         """
         The function returning what is to write into mcu data of tha outgoing 0x31 packet
@@ -305,9 +296,6 @@ class MarvelCinematicUniverse:
         usually it is some queued response
         @return: the data
         """
-        if self.reading > 0:
-            print("sending", self.response_queue[0])
-            self.reading -= 1
         if len(self.response_queue) > 0:
             return self.response_queue.pop(0)
         else:

--- a/joycontrol/mcu.py
+++ b/joycontrol/mcu.py
@@ -1,0 +1,226 @@
+import enum
+import logging
+import crc8
+
+from joycontrol.controller_state import ControllerState
+
+logger = logging.getLogger(__name__)
+
+###############################################################
+## This simulates the MCU in the right joycon/Pro-Controller ##
+###############################################################
+# This is sufficient to read one amiibo
+# multiple can mess up the internal state
+# anything but amiboo is not supported
+# TODO:
+#     - figure out the NFC-content transfer, currently everything is hardcoded to work wich amiibo
+#       see https://github.com/CTCaer/jc_toolkit/blob/5.2.0/jctool/jctool.cpp l2456ff for sugesstions
+#     - IR-camera
+#     - writing to Amiibo
+
+class MCUPowerState(enum.Enum):
+    SUSPENDED = 0x00
+    READY = 0x01
+    READY_UPDATE = 0x02
+    CONFIGURED_NFC = 0x10
+    CONFIGURED_IR = 0x11  # TODO: support this
+
+def MCU_crc(data):
+    if not isinstance(data, bytes):
+        data = bytes(data)
+    my_hash = crc8.crc8()
+    my_hash.update(data)
+    # At this point I'm not even mad this works...
+    return my_hash.digest()[0]
+
+
+class MarvelCinematicUniverse:
+    def __init__(self, controller: ControllerState):
+
+        self.power_state = MCUPowerState.SUSPENDED
+
+        # NOT USED
+        # Just a store for the remaining configuration data
+        self.configuration = None
+
+        # a cache to store the tag's data during reading
+        self.nfc_tag_data = None
+        # reading is done in multiple packets
+        # https://github.com/CTCaer/jc_toolkit/blob/5.2.0/jctool/jctool.cpp line 2537
+        # there seem to be some flow-controls and order-controls in this process
+        # which is all hardcoded here
+        self.reading_cursor = None
+
+        # NOT IMPLEMENTED
+        # remove the tag from the controller after a successfull read
+        self.remove_nfc_after_read = False
+
+        # controllerstate to look for nfc-data
+        self._controller = controller
+
+        # We are getting 0x11 commands to do something, but cannot answer directly
+        # answers are passed inside the input-reports that are sent regularly
+        # they also seem to just be repeated until a new request comes in
+        self.response = [0] * 313
+
+    def set_remove_nfc_after_read(self, value):
+        self.remove_nfc_after_read = value
+
+    def set_nfc_tag_data(self, data):
+        if not data:
+            self.nfc_tag_data = None
+        if not data is bytes:
+            data = bytes(data)
+        if len(data) != 540:
+            logger.warning("not implemented length")
+            return
+        self.nfc_tag_data = data
+
+    def _get_status_data(self):
+        """
+        create a status packet to be used when responding to 1101 commands
+        """
+        out = [0] * 313
+        if self.power_state == MCUPowerState.SUSPENDED:
+            return out
+        else:
+            out[0:7] = bytes.fromhex("01000000030005")
+            if self.power_state == MCUPowerState.CONFIGURED_NFC:
+                out[7] = 0x04
+            else:
+                out[7] = 0x01
+        out[-1] = MCU_crc(out[0:-1])
+        return out
+
+    # I don't actually know if we are supposed to change the MCU-data based on
+    # regular subcommands, but the switch is spamming the status-requests anyway,
+    # so sending responses seems to not hurt
+
+    def set_power_state_cmd(self, power_state):
+        # 1 == (READY = 1) evaluates to false. WHY?
+        if power_state in (MCUPowerState.SUSPENDED.value, MCUPowerState.READY.value):
+            self.power_state = MCUPowerState(power_state)
+            self.response = [0] * 313
+        if power_state == MCUPowerState.READY_UPDATE:
+            logger.error("NFC Update not implemented")
+        print(f"MCU: went into power_state {power_state}")
+        if self.power_state == MCUPowerState.SUSPENDED:
+            # the response probably doesnt matter.
+            self.response[0] = 0xFF
+            self.response[-1] = 0x6F
+        elif self.power_state == MCUPowerState.READY:
+            # this one does however
+            self.response[1] = 1
+            self.response[-1] = 0xc1
+
+    def set_config_cmd(self, config):
+        if self.power_state == MCUPowerState.SUSPENDED:
+            if config[3] == 0:
+                # the switch does this during initial setup, presumably to disable
+                # any MCU weirdness
+                pass
+            else:
+                logger.warning("Set MCU Config not in READY mode")
+        elif self.power_state == MCUPowerState.READY:
+            self.configuration = config
+            logger.info(f"MCU Set configuration{self.configuration}")
+            self.response[0:7] = bytes.fromhex("01000000030005")
+            # see https://github.com/CTCaer/jc_toolkit/blob/5.2.0/jctool/jctool.cpp l 2359 for values
+            if config[2] == 4:
+                # configure into NFC
+                self.response[7] = 0x04
+                self.power_state = MCUPowerState.CONFIGURED_NFC
+            elif config[2] == 1:
+                # deconfigure / disable
+                self.response[7] = 0x01
+                self.power_state = MCUPowerState.READY
+            #elif config[2] == 5: IR-Camera
+            #elif config[2] == 6: FW-Update Maybe
+            else:
+                logger.error("Not implemented configuration written")
+                self.response[7] = 0x01
+        self.response[-1] = MCU_crc(self.response[0:-1])
+
+    def received_11(self, subcommand, subcommanddata):
+        if self.reading_cursor is not None:
+            return
+        self.response = [0] * 313
+        if subcommand == 0x01:
+            # status request, respond with string and Powerstate
+            self.response[0:7] = bytes.fromhex("01000000030005")
+            self.response[7] = 0x04 if self.power_state == MCUPowerState.CONFIGURED_NFC else 0x01
+        elif subcommand == 0x02:
+            # NFC command
+            if self.power_state != MCUPowerState.CONFIGURED_NFC:
+                logger.warning("NFC command outside NFC mode, ignoring")
+            elif subcommanddata[0] == 0x04:
+                # Start discovery
+                self.response[0:7] = bytes.fromhex("2a000500000931")
+            elif subcommanddata[0] == 0x01:
+                # Start polling
+                self.set_nfc_tag_data(self._controller.get_nfc())
+                if self.nfc_tag_data:
+                    # send the tag we found
+                    self.response[0:16] = bytes.fromhex("2a000500000931090000000101020007")
+                    self.response[16:19] = self.nfc_tag_data[0:3]
+                    self.response[19:23] = self.nfc_tag_data[4:8]
+                else:
+                    # send found nothing
+                    self.response[0:8] = bytes.fromhex("2a00050000093101")
+                    # we could report the tag immediately, but the switch doesn't like too much success
+                    # TODO: better way to delay tag detection
+                    logger.info("MCU: Looking for tag")
+            elif subcommanddata[0] == 0x06:
+                # start reading
+                if not self.reading_cursor:
+                    self.reading_cursor = 0
+            #elif subcommanddata[0] == 0x00: # cancel eveyhting -> exit mode?
+            elif subcommanddata[0] == 0x02:
+                # stop Polling
+                # AKA discovery again
+                self.response[0:7] = bytes.fromhex("2a000500000931")
+        self.response[-1] = MCU_crc(self.response[0:-1])
+
+    def get_data(self):
+        if self.reading_cursor is not None:
+            # reading seems to be just packets back to back, so we have to rewrite
+            # each when sending them
+            # TODO: Use a packet queue for this
+            self.response = [0] * 313
+            if self.reading_cursor == 0:
+                # Data is sent in 2 packages plus a trailer
+                # the first one contains a lot of fixed header and the UUID
+                # the length and packetnumber is in there somewhere, see
+                # https://github.com/CTCaer/jc_toolkit/blob/5.2.0/jctool/jctool.cpp line 2523ff
+                self.response[0:15] = bytes.fromhex("3a0007010001310200000001020007")
+                self.response[15:18] = self.nfc_tag_data[0:3]
+                self.response[18:22] = self.nfc_tag_data[4:8]
+                self.response[22:67] = bytes.fromhex(
+                    "000000007DFDF0793651ABD7466E39C191BABEB856CEEDF1CE44CC75EAFB27094D087AE803003B3C7778860000")
+                self.response[67:-1] = self.nfc_tag_data[0:245]
+            elif self.reading_cursor == 1:
+                # the second one is mostely data, followed by presumably zeroes (zeroes work)
+                self.response[0:7] = bytes.fromhex("3a000702000927")
+                self.response[7:302] = self.nfc_tag_data[245:540]
+            elif self.reading_cursor == 2:
+                # the trailer includes the UUID again
+                self.response[0:16] = bytes.fromhex("2a000500000931040000000101020007")
+                self.response[16:19] = self.nfc_tag_data[0:3]
+                self.response[19:23] = self.nfc_tag_data[4:8]
+                self.nfc_tag_data = None
+                if self.remove_nfc_after_read:
+                    self._controller.set_nfc(None)
+            elif self.reading_cursor == 3:
+                # we are done but still need a graceful shutdown
+                # HACK: sending the SUSPENDED response seems to not crash it
+                # The next thing the switch requests sometimes is start discovery
+                self.reading_cursor = None
+                # self.nfc_tag_data = None
+                self.response[0] = 0xff
+                # if self.remove_nfc_after_read:
+                #    self._controller.set_nfc(None)
+            if self.reading_cursor is not None:
+                self.reading_cursor += 1
+            self.response[-1] = MCU_crc(self.response[0:-1])
+        return self.response
+

--- a/joycontrol/protocol.py
+++ b/joycontrol/protocol.py
@@ -39,9 +39,9 @@ class ControllerProtocol(BaseProtocol):
         self._controller_state = ControllerState(self, controller, spi_flash=spi_flash)
         self._controller_state_sender = None
         self._writer = None
-        # daley between two input reports
+        # delay between two input reports
         self.send_delay = 1/60 if not grip_menu else 1/15
-        
+
         self._mcu = MarvelCinematicUniverse(self._controller_state)
 
         # None = Send empty input reports & answer to sub commands
@@ -192,7 +192,6 @@ class ControllerProtocol(BaseProtocol):
             # TODO Rumble
             pass
         elif output_report_id == OutputReportID.REQUEST_IR_NFC_MCU:
-            # TODO: support 0x11 outputs in OutputReport
             self._mcu.received_11(report.data[11], report.get_sub_command_data())
             pass
         else:
@@ -377,7 +376,6 @@ class ControllerProtocol(BaseProtocol):
         await self.write(input_report)
 
     async def _command_set_nfc_ir_mcu_state(self, sub_command_data):
-        # TODO NFC
         input_report = InputReport()
         input_report.set_input_report_id(0x21)
         input_report.set_misc()

--- a/joycontrol/protocol.py
+++ b/joycontrol/protocol.py
@@ -15,17 +15,17 @@ from joycontrol.mcu import MarvelCinematicUniverse
 logger = logging.getLogger(__name__)
 
 
-def controller_protocol_factory(controller: Controller, spi_flash=None):
+def controller_protocol_factory(controller: Controller, spi_flash=None, reconnect = False):
     if isinstance(spi_flash, bytes):
         spi_flash = FlashMemory(spi_flash_memory_data=spi_flash)
 
     def create_controller_protocol():
-        return ControllerProtocol(controller, spi_flash=spi_flash)
+        return ControllerProtocol(controller, spi_flash=spi_flash, grip_menu = not reconnect)
 
     return create_controller_protocol
 
 class ControllerProtocol(BaseProtocol):
-    def __init__(self, controller: Controller, spi_flash: FlashMemory = None):
+    def __init__(self, controller: Controller, spi_flash: FlashMemory = None, grip_menu = False):
         self.controller = controller
         self.spi_flash = spi_flash
 
@@ -40,8 +40,8 @@ class ControllerProtocol(BaseProtocol):
         self._controller_state_sender = None
         self._writer = None
         # daley between two input reports
-        self.send_delay = 1/15
-
+        self.send_delay = 1/60 if not grip_menu else 1/15
+        
         self._mcu = MarvelCinematicUniverse(self._controller_state)
 
         # None = Send empty input reports & answer to sub commands

--- a/joycontrol/report.py
+++ b/joycontrol/report.py
@@ -10,7 +10,7 @@ class InputReport:
     """
     def __init__(self, data=None):
         if not data:
-            self.data = [0x00] * 364
+            self.data = [0x00] * 363
             # all input reports are prepended with 0xA1
             self.data[0] = 0xA1
         else:
@@ -113,12 +113,11 @@ class InputReport:
             self.data[i] = 0x00
 
     def set_ir_nfc_data(self, data):
-        if 50 + len(data) > len(self.data):
-            raise ValueError('Too much data.')
-
-        # write to data
-        for i in range(len(data)):
-            self.data[50 + i] = data[i]
+        if len(data) > 313:
+            raise ValueError(f'Too much data {len(data)} > 313.')
+        elif len(data) != 313:
+            print("warning : too short mcu data")
+        self.data[50:50+len(data)] = data
 
     def reply_to_subcommand_id(self, _id):
         if isinstance(_id, SubCommand):

--- a/joycontrol/transport.py
+++ b/joycontrol/transport.py
@@ -64,30 +64,6 @@ class L2CAP_Transport(asyncio.Transport):
         callback = utils.create_error_check_callback(ignore=asyncio.CancelledError)
         self._read_thread.add_done_callback(callback)
 
-    async def set_reader(self, reader: asyncio.Future):
-        """
-        Cancel the currently running reader and register the new one.
-        A reader is a coroutine that calls this transports 'read' function.
-        The 'read' function calls can be paused by calling pause_reading of this transport.
-        :param reader: future reader
-        """
-        if self._read_thread is not None:
-            # cancel currently running reader
-            if self._read_thread.cancel():
-                try:
-                    await self._read_thread
-                except asyncio.CancelledError:
-                    pass
-
-        # Create callback for debugging in case the reader is failing
-        err_callback = utils.create_error_check_callback(ignore=asyncio.CancelledError)
-        reader.add_done_callback(err_callback)
-
-        self._read_thread = reader
-
-    def get_reader(self):
-        return self._read_thread
-
     async def read(self):
         """
         Read data from the underlying socket. This function waits,

--- a/mcu.md
+++ b/mcu.md
@@ -1,0 +1,103 @@
+
+# MCU
+MarvelCinematicUniverse?
+
+This is a chip on the switch's controllers handling all kinds of high data throughput stuff.
+
+There seem to be 5 modes (OFF, starting, ON, NFC, IR, UPDATE) and a 'busy' flag.
+
+Requests are being sent by the switch using 11 output reports, responses are piggibacked to regular input using the MCU-datafield in 31 input reports (and everything is sent as a response to a request). All responses feature a checksum in the last byte that is computed as follows:
+
+checksum: `[crc8(mcu_data[0:-1])]`
+
+Request notation: The values given will always be the byte after `a2` and the one ten bytes after that (maybe followed by subsequent bytes)
+
+All numbers are in continuous hexadecimal
+
+# Generic MCU requests
+
+* If there is no response to be sent, the MCU-datafield is
+
+  `no_request`: `ff00....00[checksum]`
+
+* At first 31 mode is enabled. (`01 0331`)
+
+  `response`: `0100...00[checksum]`
+
+* then the MCU is enabled (`01 2201`)
+
+  the MCU goes through starting -> firmware-update -> on, not sure if we have to respond to this, the next command is always a status request so sending this dosn't hurt.
+
+  The firware-update phase can (and should) be skipped.
+
+  response: `[status | no_request]`
+
+* A status request (`11 01`), response:
+
+  `status`: `0100[busy]0008001b[power_state]`
+
+  where busy is `ff` after initial enable for a while, then goes to `00`
+and power_state is `01` for off, `00` for starting, `01` for on, `04` for NFC mode, `06` for firmware-update (this is not sure)
+
+## NFC & Amiibo
+
+Here I describe what I found the nfc-reading process of amiibos looks like:
+
+### generic stuff:
+
+* the Tag data `nfc_data` is 540 bytes in length
+
+* the UID is 7 of those bytes a follows:
+
+  `tag_uid`: `[nfc_data(0;3(][nfc_data(4;8(]`
+
+### NFC Requests
+
+* command: configure NFC (`01 2121`)
+
+  response: nothing (but the command-ack is weird)
+
+* get status / start discovery: `11 0204`
+
+  This is spammed like hell and seems to be some other kind of nfc-status-request
+
+  `nfc_status`: `2a000500000931[nfc_state]`
+
+  where nfc_state is
+  - `00` for nothing/polling startup or something like this
+  - `01` for polling without success
+  - `01` for polling with success, followed by `poll_success`: `0000000101020007[tag_uid]`
+  - `02` for pending read, followed by `[poll_success]`
+  - `09` for polling with success, same tag as last time, followed by `[poll_success]`
+
+  Note: the joycon thrice reported 09 followed by just 00. in response to 0204 commands after stop-polling
+
+* poll (`11 0201`)
+
+  look for a new nfc tag now
+
+  response: noting, maybe `[nfc_status]`
+
+* read (`11 0206`)
+
+  respond with the 3 read packets read1 read2 read3 followed by no_request
+
+  Note: it seems every packet is requested individually using a 0204, as on of the bytes in the request increments from 0 to 3 shortly before/after the data is sent.
+
+  the Packets:
+
+  read1: `3a0007010001310200000001020007[TAG_UID]000000007DFDF0793651ABD7466E39C191BABEB856CEEDF1CE44CC75EAFB27094D087AE803003B3C7778860000[nfc_data(0;245(][checksum]`
+
+  read2: `3a000702000927[nfc data (245;540(][checksum]`
+
+  read3: `2a000500000931040000000101020007[TAG_UID]00...00[checksum]`
+
+* stop polling (`11 0202`)
+
+  after a poll, presumably stop looking for a tag discovered during poll command
+
+  no response
+
+* cancel (`11 0200`)
+
+  No idea

--- a/mcu.md
+++ b/mcu.md
@@ -61,7 +61,7 @@ Here I describe what I found the nfc-reading process of amiibos looks like:
 
   This is spammed like hell and seems to be some other kind of nfc-status-request
 
-  `nfc_status`: `2a000500000931[nfc_state]`
+  `nfc_status`: `2a000500000931[nfc_state]00..00[checksum]`
 
   where nfc_state is
   - `00` for nothing/polling startup or something like this
@@ -88,7 +88,7 @@ Here I describe what I found the nfc-reading process of amiibos looks like:
 
   read1: `3a0007010001310200000001020007[TAG_UID]000000007DFDF0793651ABD7466E39C191BABEB856CEEDF1CE44CC75EAFB27094D087AE803003B3C7778860000[nfc_data(0;245(][checksum]`
 
-  read2: `3a000702000927[nfc data (245;540(][checksum]`
+  read2: `3a000702000927[nfc_data(245;540(][checksum]`
 
   read3: `2a000500000931040000000101020007[TAG_UID]00...00[checksum]`
 
@@ -101,3 +101,9 @@ Here I describe what I found the nfc-reading process of amiibos looks like:
 * cancel (`11 0200`)
 
   No idea
+
+# Resources
+
+* [jctool.cpp](https://github.com/CTCaer/jc_toolkit/blob/5.2.0/jctool/jctool.cpp) c.a. line 2523
+
+* [bluetooth_hid_subcommands.md](https://github.com/dekuNukem/Nintendo_Switch_Reverse_Engineering/blob/master/bluetooth_hid_subcommands_notes.md)

--- a/run_controller_cli.py
+++ b/run_controller_cli.py
@@ -248,7 +248,7 @@ def _register_commands_with_controller_state(controller_state, cli):
             nfc <file_name>          Set controller state NFC content to file
             nfc remove               Remove NFC content from controller state
         """
-        logger.error('NFC Support was removed from joycontrol - see https://github.com/mart1nro/joycontrol/issues/80')
+        #logger.error('NFC Support was removed from joycontrol - see https://github.com/mart1nro/joycontrol/issues/80')
         if controller_state.get_controller() == Controller.JOYCON_L:
             raise ValueError('NFC content cannot be set for JOYCON_L')
         elif not args:
@@ -260,12 +260,16 @@ def _register_commands_with_controller_state(controller_state, cli):
             _loop = asyncio.get_event_loop()
             with open(args[0], 'rb') as nfc_file:
                 content = await _loop.run_in_executor(None, nfc_file.read)
+                logger.info("CLI: Set nfc content")
                 controller_state.set_nfc(content)
 
     cli.add_command(nfc.__name__, nfc)
 
 
 async def _main(args):
+    # Get controller name to emulate from arguments
+    controller = Controller.from_arg(args.controller)
+
     # parse the spi flash
     if args.spi_flash:
         with open(args.spi_flash, 'rb') as spi_flash_file:
@@ -274,8 +278,6 @@ async def _main(args):
         # Create memory containing default controller stick calibration
         spi_flash = FlashMemory()
 
-    # Get controller name to emulate from arguments
-    controller = Controller.from_arg(args.controller)
 
     with utils.get_output(path=args.log, default=None) as capture_file:
         # prepare the the emulated controller


### PR DESCRIPTION
This mainly implements enough of the NFC functionality to simulate amiibos for reading. The implementations core is in mcu.py, but this is not some rewrite of the old copyrighted code.

There are still some hacks in detecting and storing the tag but it seems stable om my end.

This is currently only tested using Splatoon2 and Pro-Controller on my laptop (Acer spin 5) using PopOS based on Ubuntu 20.04 running bluez 5.53-0ubuntu3

my command to test this:
# python3 run_controller_cli.py -d hci0 -r <Switch Mac> --nfc <Some Amiibo dump in found online> PRO_CONTROLLER
And it successfully transmits the amiibos data and wants me to register a user.

TODO:
* more MCU-functionallity
* NFC-Write
* validate right Joycon working
* validate registered Amiibo working

Other changes in the merge:
* removed this reader injection into transport
* added "click" command
* partially fixed the input-speed-change improving latency
* some documentation on how it works