### PR TITLE
Fix: flow control issues

### DIFF
--- a/joycontrol/protocol.py
+++ b/joycontrol/protocol.py
@@ -163,7 +163,7 @@ class ControllerProtocol(BaseProtocol):
                             reply_send = await self._reply_to_sub_command(report)
                         elif output_report_id == OutputReportID.REQUEST_IR_NFC_MCU:
                             # TODO NFC
-                            raise NotImplementedError('NFC communictation is not implemented.')                            
+                            raise NotImplementedError('NFC communication is not implemented.')
                         else:
                             logger.warning(f'Report unknown output report "{output_report_id}" - IGNORE')
                     except ValueError as v_err:
@@ -171,10 +171,8 @@ class ControllerProtocol(BaseProtocol):
                     except NotImplementedError as err:
                         logger.warning(err)
 
-                if reply_send:
-                    # Hack: Adding a delay here to avoid flooding during pairing
-                    await asyncio.sleep(0.3)
-                else:
+                # only send controller state when player light is set
+                if not reply_send and self.sig_set_player_lights.is_set():
                     # write 0x30 input report.
                     # TODO: set some sensor data
                     input_report.set_6axis_data()

--- a/joycontrol/server.py
+++ b/joycontrol/server.py
@@ -48,7 +48,7 @@ async def create_hid_server(protocol_factory, ctl_psm=17, itr_psm=19, device_id=
         itr_sock.setblocking(False)
         ctl_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         itr_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        
+
         try:
             hid = HidDevice(device_id=device_id)
 
@@ -112,6 +112,14 @@ async def create_hid_server(protocol_factory, ctl_psm=17, itr_psm=19, device_id=
         client_itr.connect((reconnect_bt_addr, itr_psm))
         client_ctl.setblocking(False)
         client_itr.setblocking(False)
+
+    # The bluetooth adapter will send in the correct interval as the switch expects
+    # But the socket has a send buffer and blocks when the buffer is full.
+    # setting this low allows the write method to not block for a long time, as the buffer will
+    # be send fairly quick. Example:
+    # - default on my machine 212992: ~4 seconds
+    # - 4096: ~250ms
+    client_itr.setsockopt(socket.SOL_SOCKET, socket.SO_SNDBUF, 4096)
 
     # create transport for the established connection and activate the HID protocol
     transport = L2CAP_Transport(asyncio.get_event_loop(), protocol, client_itr, client_ctl, 50, capture_file=capture_file)


### PR DESCRIPTION
This fixes flow control issues during the "Change Grip/Order" in 2 cases:
- the simple fix is during "Change Grip/Order" when the controller is not connected yet: don't send state while we have no player assigned yet
- more generic fix is during "Change Grip/Order" when the controller is already connected and has player assigned (some games do this): lower send buffer to make "push back" to the process before there is a very long wait time before the buffer is cleared out.

Would be good to test this first.